### PR TITLE
Call out when nothing was found to enhance

### DIFF
--- a/lib/lita/handlers/enhance.rb
+++ b/lib/lita/handlers/enhance.rb
@@ -111,12 +111,16 @@ module Lita
           return
         end
 
-        session.enhance!(blurry_string, level)
+        enhanced_message = session.enhance!(blurry_string, level)
 
-        if config.add_quote
-          response.reply('/quote ' + blurry_string)
+        if enhanced_message != blurry_string
+          if config.add_quote
+            response.reply('/quote ' + enhanced_message)
+          else
+            response.reply(enhanced_message)
+          end
         else
-          response.reply(blurry_string)
+          response.reply('(nothingtodohere) I could not find anything to enhance')
         end
       end
 

--- a/lib/lita/handlers/enhance/session.rb
+++ b/lib/lita/handlers/enhance/session.rb
@@ -49,16 +49,18 @@ module Lita
             e.enhance!(message, level)
           end
 
+          enhanced_message = message.dup
+
           substitutions.sort! {|a,b| a.range.begin <=> b.range.begin }
 
           current_offset = 0
           substitutions.each do |sub|
-            message[sub.range.begin + current_offset, sub.range.size] = sub.new_text
+            enhanced_message[sub.range.begin + current_offset, sub.range.size] = sub.new_text
 
             current_offset += sub.new_text.length - sub.range.size
           end
 
-          message
+          enhanced_message
         end
 
         private

--- a/spec/lita/handlers/enhance/session_spec.rb
+++ b/spec/lita/handlers/enhance/session_spec.rb
@@ -18,31 +18,31 @@ describe Lita::Handlers::Enhance::Session do
 
   it 'should edit the message to enhance it' do
     message = 'hello world box01'
-    session.enhance!(message, 1)
-    expect(message).to eq('hello world *box01*')
+    enhanced_message = session.enhance!(message, 1)
+    expect(enhanced_message).to eq('hello world *box01*')
   end
 
   it 'should enhance at the supplied level' do
     message = 'hello world box01'
-    session.enhance!(message, 2)
-    expect(message).to eq('hello world *box01 (us-west-2b)*')
+    enhanced_message = session.enhance!(message, 2)
+    expect(enhanced_message).to eq('hello world *box01 (us-west-2b)*')
   end
 
   it 'should should take care to not double enhance text', focus: true do
     message = 'hello world 10.254.74.122'
-    session.enhance!(message, 2)
-    expect(message).to eq('hello world *stg-web01 (us-west-2b)*')
+    enhanced_message = session.enhance!(message, 2)
+    expect(enhanced_message).to eq('hello world *stg-web01 (us-west-2b)*')
   end
 
   it 'should be able to enhance multiple items' do
     message = 'box01 box02'
-    session.enhance!(message, 2)
-    expect(message).to eq('*box01 (us-west-2b)* *box02 (us-west-1c)*')
+    enhanced_message = session.enhance!(message, 2)
+    expect(enhanced_message).to eq('*box01 (us-west-2b)* *box02 (us-west-1c)*')
   end
 
   it 'should be able to correctly apply substitutions that result in shorter text' do
     message = 'before 22:00:0A:FE:4A:79 F2:3C:91:56:A2:00 after'
-    session.enhance!(message, 1)
-    expect(message).to eq('before *box01* *box03* after')
+    enhanced_message = session.enhance!(message, 1)
+    expect(enhanced_message).to eq('before *box01* *box03* after')
   end
 end

--- a/spec/lita/handlers/enhance_spec.rb
+++ b/spec/lita/handlers/enhance_spec.rb
@@ -95,4 +95,9 @@ describe Lita::Handlers::Enhance, lita_handler: true do
     send_command('enhance', as: alice)
     expect(replies).to include('/quote alice *box01 (us-west-2b)*')
   end
+
+  it 'should call out when nothing could be enhanced' do
+    send_command('enhance bubbles')
+    expect(replies).to include('(nothingtodohere) I could not find anything to enhance')
+  end
 end


### PR DESCRIPTION
When the enhanced message is the same as the supplied message, we will just
return a string stating such so that the user doesn't need to scan the output
to see if anything interesting was found.