### PR TITLE
Localization support and removing HipChat specific emoji

### DIFF
--- a/lib/lita/handlers/enhance.rb
+++ b/lib/lita/handlers/enhance.rb
@@ -65,14 +65,14 @@ module Lita
       end
 
       def refresh(response)
-        response.reply("Will refresh enhance index...")
+        response.reply(t 'refresh.queued')
 
         after(0) do
           begin
             lock_and_refresh_index
-            response.reply("(successful) Refreshed enhance index")
+            response.reply(t 'refresh.success')
           rescue => e
-            response.reply("(failed) Failed to refresh enhance index. Check the logs.")
+            response.reply(t 'refresh.failed')
             log.info { "#{e.message}\n#{e.backtrace.join("\n")}" }
           end
         end
@@ -97,17 +97,17 @@ module Lita
         end
 
         unless blurry_string
-          response.reply("(failed) I need a string to enhance")
+          response.reply(t 'enhance.message_required')
           return
         end
 
         level = session.last_level + 1 unless level
 
         if level > max_level
-          response.reply("Cannot enhance above level #{max_level}")
+          response.reply(t 'enhance.level_too_high', max_level: max_level)
           return
         elsif level < 1
-          response.reply("Level must be between 1 and #{max_level}")
+          response.reply(t 'enhance.level_too_low', max_level: max_level)
           return
         end
 
@@ -120,14 +120,14 @@ module Lita
             response.reply(enhanced_message)
           end
         else
-          response.reply('(nothingtodohere) I could not find anything to enhance')
+          response.reply(t 'enhance.nothing_to_enhance')
         end
       end
 
       def stats(response)
         INDEX_MUTEX.synchronize do
-          response_msg = "Last refreshed: #{@@chef_indexer.last_refreshed || 'never'}"
-          response_msg += ("\nRefreshes every %.2f minutes" % (config.refresh_interval / 60.0))
+          response_msg = t('stats.last_refreshed', last_refreshed: (@@chef_indexer.last_refreshed.to_s || 'never'))
+          response_msg += "\n" + t('stats.refresh_frequency', refresh_mins: ('%.2f' % (config.refresh_interval / 60.0)))
           @@enhancers.each do |e|
             response_msg += "\n#{e}"
           end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,3 +2,15 @@ en:
   lita:
     handlers:
       enhance:
+        refresh:
+          queued: "Will refresh enhance index..."
+          success: "(successful) Refreshed enhance index"
+          failed: "(failed) Failed to refresh enhance index. Check the logs."
+        enhance:
+          message_required: "(failed) I need a string to enhance"
+          level_too_high: "(failed) Cannot enhance above level %{max_level}"
+          level_too_low: "(failed) Level must be between 1 and %{max_level}"
+          nothing_to_enhance: "(nothingtodohere) I could not find anything to enhance"
+        stats:
+          last_refreshed: "Last refreshed: %{last_refreshed}"
+          refresh_frequency: "Refreshes every %{refresh_mins} minutes"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,13 +4,13 @@ en:
       enhance:
         refresh:
           queued: "Will refresh enhance index..."
-          success: "(successful) Refreshed enhance index"
-          failed: "(failed) Failed to refresh enhance index. Check the logs."
+          success: "Refreshed enhance index"
+          failed: "Failed to refresh enhance index. Check the logs."
         enhance:
-          message_required: "(failed) I need a string to enhance"
-          level_too_high: "(failed) Cannot enhance above level %{max_level}"
-          level_too_low: "(failed) Level must be between 1 and %{max_level}"
-          nothing_to_enhance: "(nothingtodohere) I could not find anything to enhance"
+          message_required: "I need a string to enhance"
+          level_too_high: "Cannot enhance above level %{max_level}"
+          level_too_low: "Level must be between 1 and %{max_level}"
+          nothing_to_enhance: "I could not find anything to enhance"
         stats:
           last_refreshed: "Last refreshed: %{last_refreshed}"
           refresh_frequency: "Refreshes every %{refresh_mins} minutes"

--- a/spec/lita/handlers/enhance_spec.rb
+++ b/spec/lita/handlers/enhance_spec.rb
@@ -55,7 +55,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
 
   it 'should return an error when the enhancement level is too high' do
     send_command('enhance lvl:9 54.214.188.37')
-    expect(replies).to include('Cannot enhance above level 5')
+    expect(replies).to include('(failed) Cannot enhance above level 5')
   end
 
   it 'should allow implicitly enhancing the last enhanced message at a higher level' do

--- a/spec/lita/handlers/enhance_spec.rb
+++ b/spec/lita/handlers/enhance_spec.rb
@@ -30,74 +30,107 @@ describe Lita::Handlers::Enhance, lita_handler: true do
     sleep(0.5)
 
     expect(replies).to include('Will refresh enhance index...')
-    expect(replies).to include('(successful) Refreshed enhance index')
+    expect(replies).to include('Refreshed enhance index')
   end
 
   it 'should require a message to enhance' do
     send_command('enhance')
-    expect(replies).to include('(failed) I need a string to enhance')
+    expect(replies).to include('I need a string to enhance')
   end
 
   it 'should enhance IP addresses' do
     send_command('enhance 54.214.188.37')
-    expect(replies).to include('/quote *box01*')
+    expect(replies).to include('*box01*')
   end
 
   it 'should return text that is the same format with enhancements applied' do
     send_command('enhance Finished hinted handoff of 8826 rows to endpoint /10.254.74.121')
-    expect(replies).to include('/quote Finished hinted handoff of 8826 rows to endpoint /*box01*')
+    expect(replies).to include('Finished hinted handoff of 8826 rows to endpoint /*box01*')
   end
 
   it 'should allow increasing the level of enhancement' do
     send_command('enhance lvl:2 54.214.188.37')
-    expect(replies).to include('/quote *box01 (us-west-2b)*')
+    expect(replies).to include('*box01 (us-west-2b)*')
   end
 
   it 'should return an error when the enhancement level is too high' do
     send_command('enhance lvl:9 54.214.188.37')
-    expect(replies).to include('(failed) Cannot enhance above level 5')
+    expect(replies).to include('Cannot enhance above level 5')
   end
 
   it 'should allow implicitly enhancing the last enhanced message at a higher level' do
     # Messages are enhanced at level 1 by default
     send_command('enhance 54.214.188.37')
-    expect(replies).to include('/quote *box01*')
+    expect(replies).to include('*box01*')
 
     # Now we're re-enhancing at level 2
     send_command('enhance')
-    expect(replies).to include('/quote *box01 (us-west-2b)*')
+    expect(replies).to include('*box01 (us-west-2b)*')
   end
 
   it 'should allow implicitly enhancing the last message at an explicit level' do
     # If we explicitly enhance at level 3, the next level would be 4
     send_command('enhance lvl:3 54.214.188.37')
-    expect(replies).to include('/quote *box01 (us-west-2b, _default)*')
+    expect(replies).to include('*box01 (us-west-2b, _default)*')
 
     # A user can choose an explicit level....
     send_command('enhance lvl:1')
-    expect(replies).to include('/quote *box01*')
+    expect(replies).to include('*box01*')
 
     # ... which then is retained for the next implicit enhancement
     send_command('enhance')
-    expect(replies).to include('/quote *box01 (us-west-2b)*')
+    expect(replies).to include('*box01 (us-west-2b)*')
   end
 
   it 'implicit messages are remembered per-source' do
     send_command('enhance test user 54.214.188.37')
-    expect(replies).to include('/quote test user *box01*')
+    expect(replies).to include('test user *box01*')
 
     send_command('enhance alice 54.214.188.37', as: alice)
-    expect(replies).to include('/quote alice *box01*')
+    expect(replies).to include('alice *box01*')
 
     send_command('enhance lvl:3')
-    expect(replies).to include('/quote test user *box01 (us-west-2b, _default)*')
+    expect(replies).to include('test user *box01 (us-west-2b, _default)*')
 
     send_command('enhance', as: alice)
-    expect(replies).to include('/quote alice *box01 (us-west-2b)*')
+    expect(replies).to include('alice *box01 (us-west-2b)*')
   end
 
   it 'should call out when nothing could be enhanced' do
     send_command('enhance bubbles')
-    expect(replies).to include('(nothingtodohere) I could not find anything to enhance')
+    expect(replies).to include('I could not find anything to enhance')
+  end
+
+  describe 'under HipChat' do
+    before do
+      robot.config.robot.adapter = :hipchat
+    end
+
+    it 'should mark success using an emoji' do
+      expect(subject).to receive(:lock_and_refresh_index)
+
+      send_command('refresh enhance')
+
+      # Give the timer a chance to run
+      sleep(0.5)
+
+      expect(replies).to include('Will refresh enhance index...')
+      expect(replies).to include('(successful) Refreshed enhance index')
+    end
+
+    it 'mark failure using an emoji' do
+      send_command('enhance')
+      expect(replies).to include('(failed) I need a string to enhance')
+    end
+
+    it 'should use /quote to render mono text' do
+      send_command('enhance 54.214.188.37')
+      expect(replies).to include('/quote *box01*')
+    end
+
+    it 'should use emoji to call out when nothing was found to enhance' do
+      send_command('enhance bubbles')
+      expect(replies).to include('(nothingtodohere) I could not find anything to enhance')
+    end
   end
 end


### PR DESCRIPTION
All user facing strings have been extracted to the English localization file. Additionally, I moved the HipChat specific emoji out to helper methods which will skip it if the bot isn't running under HipChat.