### PR TITLE
Add size to !enhance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
+- 2.3.1
+- 2.2
 - 2.1
-- 2.0
 services:
   - redis-server
 sudo: false

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ you> enhance 10.214.0.1
 lita> *box01*
 
 you> enhance lvl:2 10.214.0.1
-lita> *box01 (us-west-2)*
+lita> *box01 (us-west-2, xlarge)*
 ```
 
 Machine details are obtained by indexing database of machine assets. Right now only Chef servers are indexed. Results are indexed every 15 minutes by default. Old machines are left in the index so you can identify them even after they have been torn down.
 
 ```
 you> enhance lvl:2 old-box01
-lita> ?old-box01 (us-east-1)?
+lita> ?old-box01 (us-east-1, large)?
 ```
 
 [And for fun](https://www.youtube.com/watch?v=Vxq9yj2pVWk), you can implicitly enhance previously enhanced text by just sending ```enhance```. The string to enhance is retained separately in each room that the enhance string was sent.
@@ -41,7 +41,7 @@ you> enhance 10.214.0.1
 lita> *box01*
 
 you> enhance
-lita> *box01 (us-west-2)*
+lita> *box01 (us-west-2, xlarge)*
 ```
 
 ## Installation
@@ -66,6 +66,9 @@ config.handlers.enhance.refresh_interval = 15 * 60
 
 # How long in seconds to remember messages to implicitly enhance. Default is 1 week.
 config.handlers.enhance.blurry_message_ttl = 7 * 24 * 60 * 60
+
+# Location of size attribute in chef, separated by '.'.  Default is size
+config.handlers.enhance.size_attribute = 'base.size'
 ```
 
 ## Usage

--- a/lib/lita/handlers/enhance.rb
+++ b/lib/lita/handlers/enhance.rb
@@ -38,6 +38,9 @@ module Lita
       config :add_quote, default: true
       # How long to remember the previously enhanced message for.
       config :blurry_message_ttl, default: 7 * 24 * 60 * 60 # seconds
+      # Location of size attribute in chef.
+      config :size_attribute, default: 'size'
+
 
       def setup_background_refresh(payload)
         @@chef_indexer = ChefIndexer.new(redis, config.knife_configs)

--- a/lib/lita/handlers/enhance/chef_indexer.rb
+++ b/lib/lita/handlers/enhance/chef_indexer.rb
@@ -1,4 +1,5 @@
 require 'chef'
+require 'chef/knife/core/generic_presenter'
 
 module Lita
   module Handlers
@@ -46,6 +47,7 @@ module Lita
         def node_from_chef_node(chef_node)
           Node.new.tap do |n|
             n.name = chef_node.name
+            n.size = chef_fetch_attribute(chef_node, Lita.config.handlers.enhance.size_attribute)
             n.dc = if chef_node['ec2']
                      chef_node['ec2']['placement_availability_zone']
                    elsif chef_node['cloud']
@@ -126,6 +128,14 @@ module Lita
 
         def log
           Lita.logger
+        end
+
+        def chef_presenter
+          @generic_presenter ||= Chef::Knife::Core::GenericPresenter.new(Chef::Log, Chef::Config)
+        end
+
+        def chef_fetch_attribute(chef_node, attr)
+          chef_presenter.extract_nested_value(chef_node, attr)
         end
       end
     end

--- a/lib/lita/handlers/enhance/node.rb
+++ b/lib/lita/handlers/enhance/node.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class Enhance < Handler
       class Node
-        attr_accessor :name, :dc, :environment, :fqdn, :last_seen_at
+        attr_accessor :name, :size, :dc, :environment, :fqdn, :last_seen_at
 
         # Creates a new Node instance and loads its data from Redis
         def self.load(redis, name)
@@ -25,7 +25,7 @@ module Lita
 
         def self.from_json(json)
           self.new.tap do |node|
-            %w(name dc environment fqdn).each do |field|
+            %w(name size dc environment fqdn).each do |field|
               node.send("#{field}=", json[field])
             end
             node.last_seen_at = Time.parse(json['last_seen_at']) if json['last_seen_at']
@@ -33,16 +33,16 @@ module Lita
         end
 
         def as_json
-          {name: name, dc: dc, environment: environment, fqdn: fqdn, last_seen_at: last_seen_at}
+          {name: name, dc: dc, size: size, environment: environment, fqdn: fqdn, last_seen_at: last_seen_at}
         end
 
         def render(level)
           case level
           when 1 then name
-          when 2 then "#{name} (#{dc})"
-          when 3 then "#{name} (#{dc}, #{environment})"
-          when 4 then "#{name} (#{dc}, #{environment}, last seen #{last_seen_at})"
-          when 5 then "#{fqdn} (#{dc}, #{environment}, last seen #{last_seen_at})"
+          when 2 then "#{name} (#{dc}, #{size})"
+          when 3 then "#{name} (#{dc}, #{size}, #{environment})"
+          when 4 then "#{name} (#{dc}, #{size}, #{environment}, last seen #{last_seen_at})"
+          when 5 then "#{fqdn} (#{dc}, #{size}, #{environment}, last seen #{last_seen_at})"
           end
         end
 

--- a/lita-enhance.gemspec
+++ b/lita-enhance.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec", ">= 3.0.0.beta2"
 end

--- a/spec/data/box01.json
+++ b/spec/data/box01.json
@@ -209,6 +209,7 @@
     "hostname": "box01",
     "machinename": "box01",
     "fqdn": "box01.example.com",
-    "domain": "example.com"
+    "domain": "example.com",
+    "size": "xlarge"
   }
 }

--- a/spec/data/box02.json
+++ b/spec/data/box02.json
@@ -87,6 +87,7 @@
     "machinename": "box02",
     "fqdn": "box02.example.com",
     "domain": "example.com",
+    "size": "large",
     "ec2": {
       "ami_id": "ami-6d6b6028",
       "ami_launch_index": "0",

--- a/spec/data/box03.json
+++ b/spec/data/box03.json
@@ -26,6 +26,7 @@
     "machinename": "box03",
     "fqdn": "box03.example.com",
     "domain": "example.com",
+    "size": "medium",
     "network": {
       "interfaces": {
         "lo": {

--- a/spec/data/stg-web01.json
+++ b/spec/data/stg-web01.json
@@ -83,7 +83,7 @@
     "hostname": "stg-web01",
     "machinename": "stg-web01",
     "fqdn": "stg-web01.example.com",
-    "domain": "example.com"
+    "domain": "example.com",
+    "size": "small"
   }
 }
-

--- a/spec/data/web01.json
+++ b/spec/data/web01.json
@@ -80,10 +80,12 @@
       "public_ipv4": "54.214.188.39",
       "local_ipv4": "10.254.74.123"
     },
+    "base": {
+      "size": "medium.memory"
+    },
     "hostname": "web01",
     "machinename": "web01",
     "fqdn": "web01.example.com",
     "domain": "example.com"
   }
 }
-

--- a/spec/lita/handlers/enhance/chef_indexer_spec.rb
+++ b/spec/lita/handlers/enhance/chef_indexer_spec.rb
@@ -6,6 +6,8 @@ describe Lita::Handlers::Enhance::ChefIndexer do
 
   let(:indexer) { described_class.new(redis, {}) }
 
+  let(:config) { double('Lita::Configuration', handlers: double(enhance: double(size_attribute: 'base.size'))) }
+
   it 'should be able to create Node from a Chef::Node' do
     node = indexer.node_from_chef_node(west2_chef_node)
 
@@ -13,6 +15,18 @@ describe Lita::Handlers::Enhance::ChefIndexer do
     expect(node.dc).to eq('us-west-2b')
     expect(node.environment).to eq('_default')
     expect(node.fqdn).to eq('box01.example.com')
+    expect(node.last_seen_at.to_f).to be_within(5).of(Time.now.to_f)
+  end
+
+  it 'should be able to create Node from a Chef::Node with a custom size_attribute' do
+    allow(Lita).to receive(:config) { config }
+    node = indexer.node_from_chef_node(stg_web01)
+
+    expect(node.name).to eq('web01')
+    expect(node.dc).to eq('us-west-2b')
+    expect(node.size).to eq('medium.memory')
+    expect(node.environment).to eq('_default')
+    expect(node.fqdn).to eq('web01.example.com')
     expect(node.last_seen_at.to_f).to be_within(5).of(Time.now.to_f)
   end
 end

--- a/spec/lita/handlers/enhance/enhancer_example.rb
+++ b/spec/lita/handlers/enhance/enhancer_example.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.shared_examples 'an enhancer' do
   it 'should be able to render a node' do
     expect(enhancer.render(nodes.first, 1)).to eq('*box01*')
-    expect(enhancer.render(nodes.first, 2)).to eq('*box01 (us-west-2b)*')
+    expect(enhancer.render(nodes.first, 2)).to eq('*box01 (us-west-2b, xlarge)*')
   end
 
   it 'should render an old node slightly differently' do
@@ -11,6 +11,6 @@ RSpec.shared_examples 'an enhancer' do
     node.last_seen_at = Time.now - 24 * 60 * 60
 
     expect(enhancer.render(node, 1)).to eq('?box01?')
-    expect(enhancer.render(node, 2)).to eq('?box01 (us-west-2b)?')
+    expect(enhancer.render(node, 2)).to eq('?box01 (us-west-2b, xlarge)?')
   end
 end

--- a/spec/lita/handlers/enhance/node_spec.rb
+++ b/spec/lita/handlers/enhance/node_spec.rb
@@ -8,6 +8,7 @@ describe Lita::Handlers::Enhance::Node do
     described_class.new.tap do |n|
       n.name = 'box01'
       n.dc = 'us-west-2b'
+      n.size = 'xlarge'
       n.environment = '_default'
       n.fqdn = 'box01.example.com'
       n.last_seen_at = Time.now
@@ -18,6 +19,7 @@ describe Lita::Handlers::Enhance::Node do
     node_json = node.as_json
     expect(node_json).to include(
       name: 'box01',
+      size: 'xlarge',
       dc: 'us-west-2b',
       environment: '_default',
       fqdn: 'box01.example.com'
@@ -36,10 +38,10 @@ describe Lita::Handlers::Enhance::Node do
 
   it 'should be able to render itself at differing levels of detail' do
     expect(node.render(1)).to eq('box01')
-    expect(node.render(2)).to eq('box01 (us-west-2b)')
-    expect(node.render(3)).to eq('box01 (us-west-2b, _default)')
-    expect(node.render(4)).to match /box01 \(us-west-2b, _default, last seen .*\)/
-    expect(node.render(5)).to match /box01\.example\.com \(us-west-2b, _default, last seen .*\)/
+    expect(node.render(2)).to eq('box01 (us-west-2b, xlarge)')
+    expect(node.render(3)).to eq('box01 (us-west-2b, xlarge, _default)')
+    expect(node.render(4)).to match /box01 \(us-west-2b, xlarge, _default, last seen .*\)/
+    expect(node.render(5)).to match /box01\.example\.com \(us-west-2b, xlarge, _default, last seen .*\)/
   end
 
   it 'should know if it is old' do

--- a/spec/lita/handlers/enhance/session_spec.rb
+++ b/spec/lita/handlers/enhance/session_spec.rb
@@ -25,19 +25,19 @@ describe Lita::Handlers::Enhance::Session do
   it 'should enhance at the supplied level' do
     message = 'hello world box01'
     enhanced_message = session.enhance!(message, 2)
-    expect(enhanced_message).to eq('hello world *box01 (us-west-2b)*')
+    expect(enhanced_message).to eq('hello world *box01 (us-west-2b, xlarge)*')
   end
 
   it 'should should take care to not double enhance text', focus: true do
     message = 'hello world 10.254.74.122'
     enhanced_message = session.enhance!(message, 2)
-    expect(enhanced_message).to eq('hello world *stg-web01 (us-west-2b)*')
+    expect(enhanced_message).to eq('hello world *stg-web01 (us-west-2b, small)*')
   end
 
   it 'should be able to enhance multiple items' do
     message = 'box01 box02'
     enhanced_message = session.enhance!(message, 2)
-    expect(enhanced_message).to eq('*box01 (us-west-2b)* *box02 (us-west-1c)*')
+    expect(enhanced_message).to eq('*box01 (us-west-2b, xlarge)* *box02 (us-west-1c, large)*')
   end
 
   it 'should be able to correctly apply substitutions that result in shorter text' do

--- a/spec/lita/handlers/enhance_spec.rb
+++ b/spec/lita/handlers/enhance_spec.rb
@@ -52,7 +52,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
 
   it 'should allow increasing the level of enhancement' do
     send_command('enhance lvl:2 54.214.188.37')
-    expect(replies).to include('*box01 (us-west-2b)*')
+    expect(replies).to include('*box01 (us-west-2b, xlarge)*')
   end
 
   it 'should return an error when the enhancement level is too high' do
@@ -67,13 +67,13 @@ describe Lita::Handlers::Enhance, lita_handler: true do
 
     # Now we're re-enhancing at level 2
     send_command('enhance')
-    expect(replies).to include('*box01 (us-west-2b)*')
+    expect(replies).to include('*box01 (us-west-2b, xlarge)*')
   end
 
   it 'should allow implicitly enhancing the last message at an explicit level' do
     # If we explicitly enhance at level 3, the next level would be 4
     send_command('enhance lvl:3 54.214.188.37')
-    expect(replies).to include('*box01 (us-west-2b, _default)*')
+    expect(replies).to include('*box01 (us-west-2b, xlarge, _default)*')
 
     # A user can choose an explicit level....
     send_command('enhance lvl:1')
@@ -81,7 +81,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
 
     # ... which then is retained for the next implicit enhancement
     send_command('enhance')
-    expect(replies).to include('*box01 (us-west-2b)*')
+    expect(replies).to include('*box01 (us-west-2b, xlarge)*')
   end
 
   it 'implicit messages are remembered per-source' do
@@ -92,10 +92,10 @@ describe Lita::Handlers::Enhance, lita_handler: true do
     expect(replies).to include('alice *box01*')
 
     send_command('enhance lvl:3')
-    expect(replies).to include('test user *box01 (us-west-2b, _default)*')
+    expect(replies).to include('test user *box01 (us-west-2b, xlarge, _default)*')
 
     send_command('enhance', as: alice)
-    expect(replies).to include('alice *box01 (us-west-2b)*')
+    expect(replies).to include('alice *box01 (us-west-2b, xlarge)*')
   end
 
   it 'should call out when nothing could be enhanced' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ RSpec.shared_context 'mocks' do
     chef_nodes.detect {|n| n.name == 'box03' }
   end
 
+  let(:stg_web01) do
+    chef_nodes.detect {|n| n.name == 'web01' }
+  end
+
   let(:chef_nodes) do
     Dir['spec/data/*.json'].map do |node_json|
       Chef::Node.json_create(JSON.parse(IO.read(node_json)))
@@ -30,7 +34,7 @@ RSpec.shared_context 'mocks' do
 
   let(:nodes) do
     chef_indexer = Lita::Handlers::Enhance::ChefIndexer.new(redis, {})
-    chef_nodes.map do |chef_node| 
+    chef_nodes.map do |chef_node|
       node = chef_indexer.node_from_chef_node(chef_node)
       node.store!(redis)
       node


### PR DESCRIPTION
When AWS retires one of our instances, or it goes unresponsive, many people use !enhance to work out which instance (and where) it is.  People then ask which size the instance was.  This adds the size.