### PR TITLE
Add chef roles to enhance output (levels 3 and above)

### DIFF
--- a/lib/lita/handlers/enhance/chef_indexer.rb
+++ b/lib/lita/handlers/enhance/chef_indexer.rb
@@ -54,6 +54,7 @@ module Lita
                      chef_node['cloud']['provider']
                    end
             n.environment = chef_node.environment
+            n.roles = chef_node['roles']
             n.fqdn = chef_node['fqdn']
             n.last_seen_at = Time.now
           end

--- a/lib/lita/handlers/enhance/node.rb
+++ b/lib/lita/handlers/enhance/node.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class Enhance < Handler
       class Node
-        attr_accessor :name, :size, :dc, :environment, :fqdn, :last_seen_at
+        attr_accessor :name, :size, :dc, :environment, :roles, :fqdn, :last_seen_at
 
         # Creates a new Node instance and loads its data from Redis
         def self.load(redis, name)
@@ -25,7 +25,7 @@ module Lita
 
         def self.from_json(json)
           self.new.tap do |node|
-            %w(name size dc environment fqdn).each do |field|
+            %w(name size dc environment roles fqdn).each do |field|
               node.send("#{field}=", json[field])
             end
             node.last_seen_at = Time.parse(json['last_seen_at']) if json['last_seen_at']
@@ -33,16 +33,16 @@ module Lita
         end
 
         def as_json
-          {name: name, dc: dc, size: size, environment: environment, fqdn: fqdn, last_seen_at: last_seen_at}
+          {name: name, dc: dc, size: size, environment: environment, roles: roles, fqdn: fqdn, last_seen_at: last_seen_at}
         end
 
         def render(level)
           case level
           when 1 then name
           when 2 then "#{name} (#{dc}, #{size})"
-          when 3 then "#{name} (#{dc}, #{size}, #{environment})"
-          when 4 then "#{name} (#{dc}, #{size}, #{environment}, last seen #{last_seen_at})"
-          when 5 then "#{fqdn} (#{dc}, #{size}, #{environment}, last seen #{last_seen_at})"
+          when 3 then "#{name} (#{dc}, size:#{size}, env:#{environment}, roles:#{roles.join('|')})"
+          when 4 then "#{name} (#{dc}, size:#{size}, env:#{environment}, roles:#{roles.join('|')}, last seen: #{last_seen_at})"
+          when 5 then "#{fqdn} (#{dc}, size:#{size}, env:#{environment}, roles:#{roles.join('|')}, last seen: #{last_seen_at})"
           end
         end
 

--- a/lib/lita/handlers/enhance/node.rb
+++ b/lib/lita/handlers/enhance/node.rb
@@ -40,9 +40,9 @@ module Lita
           case level
           when 1 then name
           when 2 then "#{name} (#{dc}, #{size})"
-          when 3 then "#{name} (#{dc}, size:#{size}, env:#{environment}, roles:#{roles.join('|')})"
-          when 4 then "#{name} (#{dc}, size:#{size}, env:#{environment}, roles:#{roles.join('|')}, last seen: #{last_seen_at})"
-          when 5 then "#{fqdn} (#{dc}, size:#{size}, env:#{environment}, roles:#{roles.join('|')}, last seen: #{last_seen_at})"
+          when 3 then "#{name} (#{dc}, size:#{size}, env:#{environment}, roles:[#{roles.join(', ')}])"
+          when 4 then "#{name} (#{dc}, size:#{size}, env:#{environment}, roles:[#{roles.join(', ')}], last seen: #{last_seen_at})"
+          when 5 then "#{fqdn} (#{dc}, size:#{size}, env:#{environment}, roles:[#{roles.join(', ')}], last seen: #{last_seen_at})"
           end
         end
 

--- a/spec/data/box01.json
+++ b/spec/data/box01.json
@@ -206,6 +206,10 @@
       "public_ipv4": "54.214.188.37",
       "local_ipv4": "10.254.74.121"
     },
+    "roles": [
+      "webapp",
+      "base"
+    ],
     "hostname": "box01",
     "machinename": "box01",
     "fqdn": "box01.example.com",

--- a/spec/data/box02.json
+++ b/spec/data/box02.json
@@ -152,6 +152,10 @@
       "public_ipv4": "184.169.229.1",
       "local_ipv4": "10.196.75.1"
     },
+    "roles": [
+      "webapp",
+      "base"
+    ],
     "keys": {
       "ssh": {
         "host_rsa_public": "AAAAB3NzaC1yc2EAAAABIwAAAQEA5bys9CU7N5MM1F/MhDo5WE8zerQ+We4SO97nAjlPpCquaecmDR6QqgsV2JQNHKRyaElxarfDHbPByE25xBINZJg3cQlcJjEhCqX4M7urKdLzU/rrHfOOtZ4OfTzSPH2L132fnfXzkwjvEJEjNhAzD1Vbc8eU4Kzw7r4jWBf8pAedppWltJ0bemhLmJo4vMdrW4W2ApKynNFc805TSYN91zjoK5b67/9LHYUR9DJVo1QeAgbYdD4dTv1VInEGS5x3XeFIiptLvqQxokq38uxZ+vzwDxBnFUcZ6XAEZO2QxFFUA0sSHY4mn/G/a82U5K/icMW5qtoAAofad9/ER5vR8w==",

--- a/spec/data/box03.json
+++ b/spec/data/box03.json
@@ -119,6 +119,10 @@
       "local_ipv4": null,
       "local_hostname": null,
       "provider": "linode"
-    }
+    },
+    "roles": [
+      "webapp",
+      "base"
+    ]
   }
 }

--- a/spec/data/stg-web01.json
+++ b/spec/data/stg-web01.json
@@ -80,6 +80,10 @@
       "public_ipv4": "54.214.188.38",
       "local_ipv4": "10.254.74.122"
     },
+    "roles": [
+      "db",
+      "base"
+    ],
     "hostname": "stg-web01",
     "machinename": "stg-web01",
     "fqdn": "stg-web01.example.com",

--- a/spec/data/web01.json
+++ b/spec/data/web01.json
@@ -83,6 +83,10 @@
     "base": {
       "size": "medium.memory"
     },
+    "roles": [
+      "webapp",
+      "base"
+    ],
     "hostname": "web01",
     "machinename": "web01",
     "fqdn": "web01.example.com",

--- a/spec/lita/handlers/enhance/chef_indexer_spec.rb
+++ b/spec/lita/handlers/enhance/chef_indexer_spec.rb
@@ -14,6 +14,7 @@ describe Lita::Handlers::Enhance::ChefIndexer do
     expect(node.name).to eq('box01')
     expect(node.dc).to eq('us-west-2b')
     expect(node.environment).to eq('_default')
+    expect(node.roles).to eq(["webapp", "base"])
     expect(node.fqdn).to eq('box01.example.com')
     expect(node.last_seen_at.to_f).to be_within(5).of(Time.now.to_f)
   end
@@ -26,6 +27,7 @@ describe Lita::Handlers::Enhance::ChefIndexer do
     expect(node.dc).to eq('us-west-2b')
     expect(node.size).to eq('medium.memory')
     expect(node.environment).to eq('_default')
+    expect(node.roles).to eq(["webapp", "base"])
     expect(node.fqdn).to eq('web01.example.com')
     expect(node.last_seen_at.to_f).to be_within(5).of(Time.now.to_f)
   end

--- a/spec/lita/handlers/enhance/node_spec.rb
+++ b/spec/lita/handlers/enhance/node_spec.rb
@@ -10,6 +10,7 @@ describe Lita::Handlers::Enhance::Node do
       n.dc = 'us-west-2b'
       n.size = 'xlarge'
       n.environment = '_default'
+      n.roles = ['webapp', 'base']
       n.fqdn = 'box01.example.com'
       n.last_seen_at = Time.now
     end
@@ -22,6 +23,7 @@ describe Lita::Handlers::Enhance::Node do
       size: 'xlarge',
       dc: 'us-west-2b',
       environment: '_default',
+      roles: ['webapp', 'base'],
       fqdn: 'box01.example.com'
     )
     expect(node_json[:last_seen_at]).to_not be_nil
@@ -39,9 +41,9 @@ describe Lita::Handlers::Enhance::Node do
   it 'should be able to render itself at differing levels of detail' do
     expect(node.render(1)).to eq('box01')
     expect(node.render(2)).to eq('box01 (us-west-2b, xlarge)')
-    expect(node.render(3)).to eq('box01 (us-west-2b, xlarge, _default)')
-    expect(node.render(4)).to match /box01 \(us-west-2b, xlarge, _default, last seen .*\)/
-    expect(node.render(5)).to match /box01\.example\.com \(us-west-2b, xlarge, _default, last seen .*\)/
+    expect(node.render(3)).to eq('box01 (us-west-2b, size:xlarge, env:_default, roles:webapp|base)')
+    expect(node.render(4)).to match /box01 \(us-west-2b, size:xlarge, env:_default, roles:webapp\|base, last seen: .*\)/
+    expect(node.render(5)).to match /box01\.example\.com \(us-west-2b, size:xlarge, env:_default, roles:webapp\|base, last seen: .*\)/
   end
 
   it 'should know if it is old' do

--- a/spec/lita/handlers/enhance/node_spec.rb
+++ b/spec/lita/handlers/enhance/node_spec.rb
@@ -41,9 +41,9 @@ describe Lita::Handlers::Enhance::Node do
   it 'should be able to render itself at differing levels of detail' do
     expect(node.render(1)).to eq('box01')
     expect(node.render(2)).to eq('box01 (us-west-2b, xlarge)')
-    expect(node.render(3)).to eq('box01 (us-west-2b, size:xlarge, env:_default, roles:webapp|base)')
-    expect(node.render(4)).to match /box01 \(us-west-2b, size:xlarge, env:_default, roles:webapp\|base, last seen: .*\)/
-    expect(node.render(5)).to match /box01\.example\.com \(us-west-2b, size:xlarge, env:_default, roles:webapp\|base, last seen: .*\)/
+    expect(node.render(3)).to eq('box01 (us-west-2b, size:xlarge, env:_default, roles:[webapp, base])')
+    expect(node.render(4)).to match /box01 \(us-west-2b, size:xlarge, env:_default, roles:\[webapp, base\], last seen: .*\)/
+    expect(node.render(5)).to match /box01\.example\.com \(us-west-2b, size:xlarge, env:_default, roles:\[webapp, base\], last seen: .*\)/
   end
 
   it 'should know if it is old' do

--- a/spec/lita/handlers/enhance_spec.rb
+++ b/spec/lita/handlers/enhance_spec.rb
@@ -73,7 +73,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
   it 'should allow implicitly enhancing the last message at an explicit level' do
     # If we explicitly enhance at level 3, the next level would be 4
     send_command('enhance lvl:3 54.214.188.37')
-    expect(replies).to include('*box01 (us-west-2b, size:xlarge, env:_default, roles:webapp|base)*')
+    expect(replies).to include('*box01 (us-west-2b, size:xlarge, env:_default, roles:[webapp, base])*')
 
     # A user can choose an explicit level....
     send_command('enhance lvl:1')
@@ -92,7 +92,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
     expect(replies).to include('alice *box01*')
 
     send_command('enhance lvl:3')
-    expect(replies).to include('test user *box01 (us-west-2b, size:xlarge, env:_default, roles:webapp|base)*')
+    expect(replies).to include('test user *box01 (us-west-2b, size:xlarge, env:_default, roles:[webapp, base])*')
 
     send_command('enhance', as: alice)
     expect(replies).to include('alice *box01 (us-west-2b, xlarge)*')

--- a/spec/lita/handlers/enhance_spec.rb
+++ b/spec/lita/handlers/enhance_spec.rb
@@ -73,7 +73,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
   it 'should allow implicitly enhancing the last message at an explicit level' do
     # If we explicitly enhance at level 3, the next level would be 4
     send_command('enhance lvl:3 54.214.188.37')
-    expect(replies).to include('*box01 (us-west-2b, xlarge, _default)*')
+    expect(replies).to include('*box01 (us-west-2b, size:xlarge, env:_default, roles:webapp|base)*')
 
     # A user can choose an explicit level....
     send_command('enhance lvl:1')
@@ -92,7 +92,7 @@ describe Lita::Handlers::Enhance, lita_handler: true do
     expect(replies).to include('alice *box01*')
 
     send_command('enhance lvl:3')
-    expect(replies).to include('test user *box01 (us-west-2b, xlarge, _default)*')
+    expect(replies).to include('test user *box01 (us-west-2b, size:xlarge, env:_default, roles:webapp|base)*')
 
     send_command('enhance', as: alice)
     expect(replies).to include('alice *box01 (us-west-2b, xlarge)*')


### PR DESCRIPTION
While we list the chef environment, we don't list the roles a node belongs to.

This also cleans up the display of the extra attributes to make it clearer which is which (size, env, roles, etc)